### PR TITLE
retrieve the home dir in a portable fashion

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,6 +8,7 @@ license         'bsd';
 # Specific dependencies
 requires       'DBIx::Class'            => '0.08100';
 requires       'Config::Any'            => '0.23';
+requires       'File::HomeDir'          => '0';
 
 test_requires  'Test::More'             => '0.42';
 test_requires  'DBD::SQLite'            => '0';

--- a/lib/DBIx/Class/Schema/Config.pm
+++ b/lib/DBIx/Class/Schema/Config.pm
@@ -3,6 +3,7 @@ use 5.005;
 use warnings;
 use strict;
 use base 'DBIx::Class::Schema';
+use File::HomeDir;
 
 our $VERSION = '0.001006'; # 0.1.6
 $VERSION = eval $VERSION;
@@ -70,7 +71,7 @@ sub load_credentials {
 sub filter_loaded_credentials { $_[1] };
 
 __PACKAGE__->mk_classaccessor('config_paths'); 
-__PACKAGE__->config_paths([('./dbic', $ENV{HOME} . '/.dbic', '/etc/dbic')]);
+__PACKAGE__->config_paths([('./dbic', File::HomeDir->my_home . '/.dbic', '/etc/dbic')]);
 
 1;
 

--- a/t/03_config_paths.t
+++ b/t/03_config_paths.t
@@ -3,10 +3,11 @@ use warnings;
 use strict;
 use Test::More;
 use base 'DBIx::Class::Schema::Config';
+use File::HomeDir;
 
 is_deeply(
     __PACKAGE__->config_paths,
-    [ './dbic', $ENV{HOME} . "/.dbic", "/etc/dbic"  ],
+    [ './dbic', File::HomeDir->my_home . "/.dbic", "/etc/dbic"  ],
     "_config_paths looks sane.");
 
 __PACKAGE__->config_paths( [ ( './this', '/var/www/that' ) ] );


### PR DESCRIPTION
DBIx-Class-Schema-Config can currently only recognize the homedir if $ENV{HOME} is set, which will not be the case on all platforms. File::Homedir solves this problem.
