### PR TITLE
add convoluted test dep on one of the YAMLs

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,4 +17,8 @@ test_requires  'Test::More'             => '0.42';
 test_requires  'DBD::SQLite'            => '0';
 test_requires  'Config::Any'            => '0.23';
 
+if ( !eval "use YAML::XS; 1" && !eval "use YAML::Syck 0.70; 1" ) {
+    test_requires 'YAML' => 0;
+}
+
 WriteAll;


### PR DESCRIPTION
08_integration_env.t needs one of the YAMLs so check for existence of YAML::XS or YAML::Syck and otherwise add YAML as test dep.

This just started hitting us as we added 5.24 to travis builds and `DBIx::Class::Schema::Config` was being installed before any other distro pulled in YAML. I'm not a `Module::Install` user so perhaps this is not the best solution in this case but something is needed to prevent test failures.